### PR TITLE
Adds marker panels to cratefiller

### DIFF
--- a/KPCF_config.sqf
+++ b/KPCF_config.sqf
@@ -329,6 +329,7 @@ KPCF_items = [
     "Laserbatteries",
     "UK3CB_BAF_M6_RangeTable",
     "FISH_Cream_Kit_Europe"
+    "42cdo_vs17_item"
 ];
 
 // Defines the available backpacks


### PR DESCRIPTION
FST uses marker panels to mark HLSs, this adds said marker panels to KPCF so 4/3 can provide more if requested